### PR TITLE
Implement model, authorization and error handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import os
+
 import uvicorn
 
 from service.api.app import create_app
@@ -9,7 +10,6 @@ app = create_app(config)
 
 
 if __name__ == "__main__":
-
     host = os.getenv("HOST", "127.0.0.1")
     port = int(os.getenv("PORT", "8080"))
 

--- a/service/api/app.py
+++ b/service/api/app.py
@@ -5,11 +5,11 @@ from typing import Any, Dict
 import uvloop
 from fastapi import FastAPI
 
-from ..log import app_logger, setup_logging
-from ..settings import ServiceConfig
-from .exception_handlers import add_exception_handlers
-from .middlewares import add_middlewares
-from .views import add_views
+from service.api.exception_handlers import add_exception_handlers
+from service.api.middlewares import add_middlewares
+from service.api.views import add_views
+from service.log import app_logger, setup_logging
+from service.settings import ServiceConfig
 
 __all__ = ("create_app",)
 
@@ -35,6 +35,7 @@ def create_app(config: ServiceConfig) -> FastAPI:
 
     app = FastAPI(debug=False)
     app.state.k_recs = config.k_recs
+    app.state.token = config.token
 
     add_views(app)
     add_middlewares(app)

--- a/service/api/exception_handlers.py
+++ b/service/api/exception_handlers.py
@@ -7,11 +7,10 @@ from starlette import status
 from starlette.exceptions import HTTPException
 from starlette.responses import JSONResponse
 
+from service.api.exceptions import AppException
 from service.log import app_logger
 from service.models import Error
 from service.response import create_response, server_error
-
-from .exceptions import AppException
 
 
 async def default_error_handler(

--- a/service/api/exceptions.py
+++ b/service/api/exceptions.py
@@ -17,12 +17,34 @@ class AppException(Exception):
         super().__init__()
 
 
+class ModelNotFoundError(AppException):
+    def __init__(
+        self,
+        status_code: int = HTTPStatus.NOT_FOUND,
+        error_key: str = "model_not_found",
+        error_message: str = "Model is unknown",
+        error_loc: tp.Optional[tp.Sequence[str]] = None,
+    ):
+        super().__init__(status_code, error_key, error_message, error_loc)
+
+
 class UserNotFoundError(AppException):
     def __init__(
         self,
         status_code: int = HTTPStatus.NOT_FOUND,
         error_key: str = "user_not_found",
-        error_message: str = "User is unknown",
+        error_message: str = "User not found",
+        error_loc: tp.Optional[tp.Sequence[str]] = None,
+    ):
+        super().__init__(status_code, error_key, error_message, error_loc)
+
+
+class UnauthorizedUserError(AppException):
+    def __init__(
+        self,
+        status_code: int = HTTPStatus.UNAUTHORIZED,
+        error_key: str = "token_error",
+        error_message: str = "Incorrect token",
         error_loc: tp.Optional[tp.Sequence[str]] = None,
     ):
         super().__init__(status_code, error_key, error_message, error_loc)

--- a/service/api/views.py
+++ b/service/api/views.py
@@ -1,9 +1,10 @@
 from typing import List
 
-from fastapi import APIRouter, FastAPI, Request
+from fastapi import APIRouter, Depends, FastAPI, Request
+from fastapi.security import HTTPBearer, OAuth2PasswordBearer
 from pydantic import BaseModel
 
-from service.api.exceptions import UserNotFoundError
+from service.api.exceptions import ModelNotFoundError, UnauthorizedUserError, UserNotFoundError
 from service.log import app_logger
 
 
@@ -12,7 +13,8 @@ class RecoResponse(BaseModel):
     items: List[int]
 
 
-router = APIRouter()
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+router, bearer = APIRouter(), HTTPBearer()
 
 
 @router.get(
@@ -27,21 +29,33 @@ async def health() -> str:
     path="/reco/{model_name}/{user_id}",
     tags=["Recommendations"],
     response_model=RecoResponse,
+    responses={
+        404: {
+            "description": "Incorrect User or Model",
+            "content": {"application/json": {"example": {"detail": "model_name or user_id not found"}}},
+        },
+        401: {
+            "description": "Incorrect authorization token",
+            "content": {"application/json": {"example": {"detail": "Authorization failed"}}},
+        },
+    },
 )
-async def get_reco(
-    request: Request,
-    model_name: str,
-    user_id: int,
-) -> RecoResponse:
-    app_logger.info(f"Request for model: {model_name}, user_id: {user_id}")
+async def get_reco(request: Request, model_name: str, user_id: int, token=Depends(bearer)) -> RecoResponse:
+    app_logger.info(f"Request for model: {model_name}")
+    app_logger.info(f"Request for user: {user_id}")
 
-    # Write your code here
+    if request.app.state.token != token.credentials:
+        raise UnauthorizedUserError()
 
     if user_id > 10**9:
         raise UserNotFoundError(error_message=f"User {user_id} not found")
 
+    if model_name != "some_model":
+        raise ModelNotFoundError(error_message=f"Model {model_name} not found")
+
     k_recs = request.app.state.k_recs
-    reco = list(range(k_recs))
+    reco = [42 + i for i in range(k_recs)]
+
     return RecoResponse(user_id=user_id, items=reco)
 
 

--- a/service/log.py
+++ b/service/log.py
@@ -1,7 +1,7 @@
 import logging.config
 import typing as tp
 
-from .settings import ServiceConfig
+from service.settings import ServiceConfig
 
 app_logger = logging.getLogger("app")
 access_logger = logging.getLogger("access")

--- a/service/settings.py
+++ b/service/settings.py
@@ -1,5 +1,7 @@
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+AUTH_TOKEN: str = "1234"
+
 
 class Config(BaseSettings):
     model_config = SettingsConfigDict(case_sensitive=False)
@@ -16,6 +18,7 @@ class ServiceConfig(Config):
     k_recs: int = 10
 
     log_config: LogConfig
+    token: str = AUTH_TOKEN
 
 
 def get_config() -> ServiceConfig:

--- a/tests/api/test_views.py
+++ b/tests/api/test_views.py
@@ -4,7 +4,7 @@ from starlette.testclient import TestClient
 
 from service.settings import ServiceConfig
 
-GET_RECO_PATH = "/reco/{model_name}/{user_id}"
+GET_RECO_PATH: str = "/reco/{model_name}/{user_id}"
 
 
 def test_health(
@@ -21,8 +21,9 @@ def test_get_reco_success(
 ) -> None:
     user_id = 123
     path = GET_RECO_PATH.format(model_name="some_model", user_id=user_id)
+
     with client:
-        response = client.get(path)
+        response = client.get(path, headers={"Authorization": "Bearer 1234"})
     assert response.status_code == HTTPStatus.OK
     response_json = response.json()
     assert response_json["user_id"] == user_id
@@ -35,7 +36,35 @@ def test_get_reco_for_unknown_user(
 ) -> None:
     user_id = 10**10
     path = GET_RECO_PATH.format(model_name="some_model", user_id=user_id)
+
     with client:
-        response = client.get(path)
+        response = client.get(path, headers={"Authorization": "Bearer 1234"})
+
     assert response.status_code == HTTPStatus.NOT_FOUND
     assert response.json()["errors"][0]["error_key"] == "user_not_found"
+
+
+def test_get_reco_unknown_token(
+    client: TestClient,
+) -> None:
+    user_id = 123
+    path = GET_RECO_PATH.format(model_name="some_model", user_id=user_id)
+
+    with client:
+        response = client.get(path, headers={"Authorization": "Bearer abracadabra"})
+
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+    assert response.json()["errors"][0]["error_key"] == "token_error"
+
+
+def test_get_reco_for_unknown_model(
+    client: TestClient,
+) -> None:
+    user_id = 123
+    path = GET_RECO_PATH.format(model_name="another_model", user_id=user_id)
+
+    with client:
+        response = client.get(path, headers={"Authorization": "Bearer 1234"})
+
+    assert response.status_code == HTTPStatus.NOT_FOUND
+    assert response.json()["errors"][0]["error_key"] == "model_not_found"


### PR DESCRIPTION
- Cloned the reference repository, added the basic model, which produce `42 + i` as an output, appeared in the leaderboard.
- Added authorization and tests for it.
- Added an 404 error if requested an unknown model or unknown user, added tests on it.
- Added description of errors in swagger
- All code was written under PEP8 regulations, was formatted and checked using linter.